### PR TITLE
Change type of user-defined `view_properties` in the Query Agent

### DIFF
--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -52,7 +52,7 @@ class QueryAgent(_BaseAgent):
     def run(
         self,
         query: str,
-        view_properties: Optional[List[str]] = None,
+        view_properties: Optional[dict[str, list[str]]] = None,
         context: Optional[QueryAgentResponse] = None,
     ) -> QueryAgentResponse:
         """


### PR DESCRIPTION
This changes the type of `view_properties` from `list[str]` to `dict[str, list[str]]`.