### PR TITLE
Add option to pass filters to get_objects

### DIFF
--- a/test/personalization_agent/test_personalization_agent.py
+++ b/test/personalization_agent/test_personalization_agent.py
@@ -32,7 +32,7 @@ class DummyClient:
 @pytest.fixture
 def agent() -> PersonalizationAgent:
     return PersonalizationAgent(
-        client=DummyClient(),
+        client=DummyClient(),  # type: ignore
         reference_collection="TestCollection",
     )
 

--- a/test/personalization_agent/test_personalization_agent.py
+++ b/test/personalization_agent/test_personalization_agent.py
@@ -1,0 +1,135 @@
+from unittest.mock import Mock
+from uuid import uuid4, UUID
+
+import httpx
+import pytest
+import weaviate.classes as wvc
+
+from weaviate_agents.personalization.personalization_agent import (
+    PersonalizationAgent,
+    PersonalizedQuery,
+    PersonalizationAgentGetObjectsResponse,
+)
+
+
+class DummyClient:
+    """A dummy client to simulate the Weaviate client for testing purposes."""
+
+    def __init__(self):
+        self._connection = self  # Simulate connection
+        self.url = "http://test-url:443"  # Add url attribute
+        self.additional_headers = {"Authorization": "test-token"}
+
+    def get_current_bearer_token(self) -> str:
+        """Simulate bearer token retrieval from connection.
+
+        Returns:
+            str: The test bearer token prefixed with 'Bearer '.
+        """
+        return "Bearer test-token"
+    
+
+@pytest.fixture
+def agent() -> PersonalizationAgent:
+    return PersonalizationAgent(
+        client=DummyClient(),
+        reference_collection='TestCollection',
+    )
+
+
+def test_query(agent: PersonalizationAgent):
+    query = agent.query(persona_id=uuid4())
+    assert isinstance(query, PersonalizedQuery)
+
+
+@pytest.mark.parametrize('filters, filter_request', [
+    (None, None),
+    (
+        wvc.query.Filter.by_property("title").not_equal("Avatar"),
+        {'operator': 'NotEqual', 'target': 'title', 'value': 'Avatar'}
+    ),
+    (
+        (
+            wvc.query.Filter.by_property("title").not_equal("Avatar")
+            & wvc.query.Filter.by_property("genres").not_equal("comedy")
+        ),
+        {
+            'combine': 'and', 'filters': [
+                {'operator': 'NotEqual', 'target': 'title', 'value': 'Avatar'},
+                {'operator': 'NotEqual', 'target': 'genres', 'value': 'comedy'},
+            ]
+        },
+    ),
+])
+def test_get_objects(agent: PersonalizationAgent, monkeypatch, filters, filter_request):
+    mock_response = {
+        "objects": [
+            {
+                "uuid": "ae0fc31d-2f11-4e3a-a0f8-6e64795d7db9",
+                "original_rank": 0,
+                "personalized_rank": None,
+                "properties": {
+                    "title": "The Crush",
+                    'genres': ['Drama', 'Thriller', 'Horror']
+                },
+            },
+            {
+                "uuid": "f557e407-74db-453a-95b4-9357045be38d",
+                "original_rank": 1,
+                "personalized_rank": None,
+                "properties": {
+                    "title": "Armed Response",
+                    'genres': ['Action', 'Horror', 'Thriller']
+                },
+            },
+        ],
+        "ranking_rationale": None,
+        "usage": {
+            "requests": 0,
+            "request_tokens": 0,
+            "response_tokens": 0,
+            "total_tokens": 0,
+            "details": None,
+        },
+    }
+
+    mock_httpx = Mock()
+    mock_httpx.post.return_value = httpx.Response(
+        status_code=200,
+        request=httpx.Request("post", "http://dummy-agent"),
+        json=mock_response,
+    )
+    monkeypatch.setattr("weaviate_agents.personalization.personalization_agent.httpx", mock_httpx)
+
+    persona_id = UUID('32a31598-42a8-4ed2-92d0-1273c7dbdcb0')
+    recommendations = agent.get_objects(
+        persona_id=persona_id,
+        filters=filters,
+    )
+    expected_request = {
+        'objects_request': {
+            'persona_id': '32a31598-42a8-4ed2-92d0-1273c7dbdcb0',
+            'limit': 10,
+            'recent_interactions_count': 100,
+            'exclude_interacted_items': True,
+            'decay_rate': 0.1,
+            'exclude_items': [],
+            'use_agent_ranking': True,
+            'explain_results': True,
+            'instruction': None,
+            'filters': filter_request,
+        },
+        'personalization_request': {
+            'collection_name': 'TestCollection',
+            'headers': {'Authorization': 'test-token'},
+            'item_collection_vector_name': None,
+            'create': False
+        }
+    }
+
+    mock_httpx.post.assert_called_once()
+    request_json = mock_httpx.post.call_args.kwargs["json"]
+    assert request_json == expected_request
+
+    assert isinstance(recommendations, PersonalizationAgentGetObjectsResponse)
+    assert recommendations.model_dump(mode='json') == mock_response

--- a/test/personalization_agent/test_personalization_agent.py
+++ b/test/personalization_agent/test_personalization_agent.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock
-from uuid import uuid4, UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -7,8 +7,8 @@ import weaviate.classes as wvc
 
 from weaviate_agents.personalization.personalization_agent import (
     PersonalizationAgent,
-    PersonalizedQuery,
     PersonalizationAgentGetObjectsResponse,
+    PersonalizedQuery,
 )
 
 

--- a/weaviate_agents/personalization/classes/__init__.py
+++ b/weaviate_agents/personalization/classes/__init__.py
@@ -6,7 +6,6 @@ from .query import (
     NearTextQueryParameters,
     QueryParameters,
     QueryRequest,
-    serialise_filter,
 )
 from .request import GetObjectsRequest, PersonalizationRequest
 from .response import (
@@ -30,5 +29,4 @@ __all__ = [
     "NearTextQueryParameters",
     "QueryParameters",
     "QueryRequest",
-    "serialise_filter"
 ]

--- a/weaviate_agents/personalization/classes/__init__.py
+++ b/weaviate_agents/personalization/classes/__init__.py
@@ -6,8 +6,9 @@ from .query import (
     NearTextQueryParameters,
     QueryParameters,
     QueryRequest,
+    serialise_filter,
 )
-from .request import PersonalizationRequest
+from .request import GetObjectsRequest, PersonalizationRequest
 from .response import (
     PersonalizationAgentGetObjectsResponse,
     PersonalizedObject,
@@ -22,10 +23,12 @@ __all__ = [
     "PersonalizedObject",
     "Usage",
     "PersonalizedQueryResponse",
+    "GetObjectsRequest",
     "PersonalizationRequest",
     "BM25QueryParameters",
     "HybridQueryParameters",
     "NearTextQueryParameters",
     "QueryParameters",
     "QueryRequest",
+    "serialise_filter"
 ]

--- a/weaviate_agents/personalization/classes/request.py
+++ b/weaviate_agents/personalization/classes/request.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict, Union
+from typing import Annotated, Dict, List, Union, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -22,8 +22,8 @@ class GetObjectsRequest(BaseModel):
     recent_interactions_count: int = 100
     exclude_interacted_items: bool = True
     decay_rate: float = 0.1
-    exclude_items: list[str] = []
+    exclude_items: List[str] = []
     use_agent_ranking: bool = True
     explain_results: bool = True
-    instruction: str | None = None
-    filters: Annotated[_Filters, serialise_filter] | None = None
+    instruction: Optional[str] = None
+    filters: Optional[Annotated[_Filters, serialise_filter]] = None

--- a/weaviate_agents/personalization/classes/request.py
+++ b/weaviate_agents/personalization/classes/request.py
@@ -1,6 +1,8 @@
-from typing import Dict, Union
+from typing import Annotated, Dict, Union
+from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from weaviate.collections.classes.filters import _Filters
 
 from weaviate_agents.personalization.classes.query import serialise_filter
 
@@ -13,4 +15,15 @@ class PersonalizationRequest(BaseModel):
 
 
 class GetObjectsRequest(BaseModel):
-    pass
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    persona_id: UUID
+    limit: int = 10
+    recent_interactions_count: int = 100
+    exclude_interacted_items: bool = True
+    decay_rate: float = 0.1
+    exclude_items: list[str] = []
+    use_agent_ranking: bool = True
+    explain_results: bool = True
+    instruction: str | None = None
+    filters: Annotated[_Filters, serialise_filter] | None = None

--- a/weaviate_agents/personalization/classes/request.py
+++ b/weaviate_agents/personalization/classes/request.py
@@ -6,6 +6,7 @@ from weaviate.collections.classes.filters import _Filters
 
 from weaviate_agents.personalization.classes.query import serialise_filter
 
+
 class PersonalizationRequest(BaseModel):
     collection_name: str
     create: bool = True

--- a/weaviate_agents/personalization/classes/request.py
+++ b/weaviate_agents/personalization/classes/request.py
@@ -2,6 +2,7 @@ from typing import Dict, Union
 
 from pydantic import BaseModel
 
+from weaviate_agents.personalization.classes.query import serialise_filter
 
 class PersonalizationRequest(BaseModel):
     collection_name: str
@@ -9,3 +10,7 @@ class PersonalizationRequest(BaseModel):
     headers: Union[Dict[str, str], None] = None
     persona_properties: Union[Dict[str, str], None] = None
     item_collection_vector_name: Union[str, None] = None
+
+
+class GetObjectsRequest(BaseModel):
+    pass

--- a/weaviate_agents/personalization/classes/request.py
+++ b/weaviate_agents/personalization/classes/request.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Dict, List, Union, Optional
+from typing import Annotated, Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict

--- a/weaviate_agents/personalization/personalization_agent.py
+++ b/weaviate_agents/personalization/personalization_agent.py
@@ -391,7 +391,7 @@ class PersonalizationAgent(_BaseAgent):
             filters=filters,
         )
         request_data = {
-            "objects_request": objects_request.model_dump(mode='json'),
+            "objects_request": objects_request.model_dump(mode="json"),
             "personalization_request": {
                 "collection_name": self._reference_collection,
                 "headers": self._connection.additional_headers,

--- a/weaviate_agents/personalization/personalization_agent.py
+++ b/weaviate_agents/personalization/personalization_agent.py
@@ -379,22 +379,19 @@ class PersonalizationAgent(_BaseAgent):
             recent_interactions_count: The number of recent interactions to consider
         """
         objects_request = GetObjectsRequest(
-            ...
+            persona_id=persona_id,
+            limit=limit,
+            recent_interactions_count=recent_interactions_count,
+            exclude_interacted_items=exclude_interacted_items,
+            decay_rate=decay_rate,
+            exclude_items=exclude_items,
+            use_agent_ranking=use_agent_ranking,
+            explain_results=explain_results,
+            instruction=instruction,
+            filters=filters,
         )
         request_data = {
             "objects_request": objects_request.model_dump(mode='json'),
-            # TODO: Add get_personalization_request method?
-            #"objects_request": {
-            #    "persona_id": str(persona_id),
-            #    "limit": limit,
-            #    "recent_interactions_count": recent_interactions_count,
-            #    "exclude_interacted_items": exclude_interacted_items,
-            #    "decay_rate": decay_rate,
-            #    "exclude_items": exclude_items,
-            #    "use_agent_ranking": use_agent_ranking,
-            #    "explain_results": explain_results,
-            #    "instruction": instruction,
-            #},
             "personalization_request": {
                 "collection_name": self._reference_collection,
                 "headers": self._connection.additional_headers,

--- a/weaviate_agents/personalization/personalization_agent.py
+++ b/weaviate_agents/personalization/personalization_agent.py
@@ -3,17 +3,17 @@ from uuid import UUID
 
 import httpx
 from weaviate.classes.config import DataType
-from weaviate.collections.classes.filters import _Filters
 from weaviate.client import WeaviateClient
+from weaviate.collections.classes.filters import _Filters
 
 from weaviate_agents.base import _BaseAgent
 from weaviate_agents.personalization.classes import (
+    GetObjectsRequest,
     Persona,
     PersonaInteraction,
     PersonaInteractionResponse,
     PersonalizationAgentGetObjectsResponse,
     PersonalizationRequest,
-    GetObjectsRequest,
 )
 from weaviate_agents.personalization.query import PersonalizedQuery
 

--- a/weaviate_agents/personalization/personalization_agent.py
+++ b/weaviate_agents/personalization/personalization_agent.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 import httpx
 from weaviate.classes.config import DataType
+from weaviate.collections.classes.filters import _Filters
 from weaviate.client import WeaviateClient
 
 from weaviate_agents.base import _BaseAgent
@@ -12,6 +13,7 @@ from weaviate_agents.personalization.classes import (
     PersonaInteractionResponse,
     PersonalizationAgentGetObjectsResponse,
     PersonalizationRequest,
+    GetObjectsRequest,
 )
 from weaviate_agents.personalization.query import PersonalizedQuery
 
@@ -367,6 +369,7 @@ class PersonalizationAgent(_BaseAgent):
         use_agent_ranking: bool = True,
         explain_results: bool = True,
         instruction: Optional[str] = None,
+        filters: Optional[_Filters] = None,
     ) -> PersonalizationAgentGetObjectsResponse:
         """Get Personalized objects for a specific persona.
 
@@ -375,18 +378,23 @@ class PersonalizationAgent(_BaseAgent):
             limit: The maximum number of objects to return
             recent_interactions_count: The number of recent interactions to consider
         """
+        objects_request = GetObjectsRequest(
+            ...
+        )
         request_data = {
-            "objects_request": {
-                "persona_id": str(persona_id),
-                "limit": limit,
-                "recent_interactions_count": recent_interactions_count,
-                "exclude_interacted_items": exclude_interacted_items,
-                "decay_rate": decay_rate,
-                "exclude_items": exclude_items,
-                "use_agent_ranking": use_agent_ranking,
-                "explain_results": explain_results,
-                "instruction": instruction,
-            },
+            "objects_request": objects_request.model_dump(mode='json'),
+            # TODO: Add get_personalization_request method?
+            #"objects_request": {
+            #    "persona_id": str(persona_id),
+            #    "limit": limit,
+            #    "recent_interactions_count": recent_interactions_count,
+            #    "exclude_interacted_items": exclude_interacted_items,
+            #    "decay_rate": decay_rate,
+            #    "exclude_items": exclude_items,
+            #    "use_agent_ranking": use_agent_ranking,
+            #    "explain_results": explain_results,
+            #    "instruction": instruction,
+            #},
             "personalization_request": {
                 "collection_name": self._reference_collection,
                 "headers": self._connection.additional_headers,


### PR DESCRIPTION
## Description
Adds the option to include filters when using the `get_objects` method.


## Related Issue

Closes https://github.com/weaviate/agents/issues/405.

## Screenshots/Visuals (if applicable)

<img width="1130" alt="Screenshot 2025-04-16 at 4 50 15 pm" src="https://github.com/user-attachments/assets/7e6afce4-79d5-431b-aaca-ff5dad45059b" />