### PR TITLE
Add target/named vector support to QA

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ wheels = [
 
 [[package]]
 name = "weaviate-agents"
-version = "0.4.5"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Union
 
 import httpx
 from weaviate.client import WeaviateClient
+from weaviate.collections.classes.grpc import TargetVectorJoinType
 
 from weaviate_agents.base import _BaseAgent
 from weaviate_agents.query.classes import CollectionDescription, QueryAgentResponse
@@ -54,6 +55,9 @@ class QueryAgent(_BaseAgent):
         query: str,
         view_properties: Optional[List[str]] = None,
         context: Optional[QueryAgentResponse] = None,
+        target_vector: Optional[
+            Union[TargetVectorJoinType, dict[str, TargetVectorJoinType]]
+        ] = None,
     ) -> QueryAgentResponse:
         """
         Run the query agent.
@@ -63,6 +67,9 @@ class QueryAgent(_BaseAgent):
             view_properties: Optional list of of property names the agent has the ability to view
                 across all collections.
             context: Optional previous response from the agent.
+            target_vector: Optional target vector for the query if a collection uses named vector. When
+            mulitple collections are provided to the query agent, a dictionary must be used mapping
+            collection names to target vectors.
         """
         request_body = {
             "query": query,
@@ -76,6 +83,7 @@ class QueryAgent(_BaseAgent):
             "tenant": None,
             "previous_response": context.model_dump() if context else None,
             "system_prompt": self._system_prompt,
+            "target_vector": target_vector,
         }
 
         response = httpx.post(


### PR DESCRIPTION
- Adds support to `QueryAgents` `run()` method to support the `target_vector` argument which is to be used in cases where a underlying collection is configured using [named vectors](https://weaviate.io/developers/weaviate/config-refs/schema/multi-vector)
- If the constructor for the QA consists of multiple collections then the structure of `target_vector` must be a dict mapping of collection names to the underlying target vector name for example:
```python
# Assume `client` is your WeaviateClient instance
agent = QueryAgent(
    client,
    collections=["collection1", "collection2"],
)

# Specify a target vector for each collection
target_vector = {
    "collection1": "vectorA",
    "collection2": "vectorB"
}

response = agent.run("your query here", target_vector=target_vector)
```