### PR TITLE
Support UUIDs via update_by_uuids, clean up common code

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -948,7 +948,7 @@ wheels = [
 
 [[package]]
 name = "weaviate-agents"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },

--- a/weaviate_agents/transformation/transformation_agent.py
+++ b/weaviate_agents/transformation/transformation_agent.py
@@ -1,4 +1,5 @@
 from typing import List, Union
+from uuid import UUID
 
 import httpx
 from weaviate.client import WeaviateClient
@@ -57,18 +58,7 @@ class TransformationAgent(_BaseAgent):
 
         self.t_host = f"{self._agents_host}/transformation"
 
-    def update_all(self) -> TransformationResponse:
-        """Triggers all configured transformation operations on the collection.
-
-        Returns:
-            TransformationResponse: response with workflow ID for tracking transformation progress.
-
-        Raises:
-            httpx.HTTPError: If there is an error communicating with the transformation service.
-            ValueError: If the operations are not properly configured or if there are duplicate
-                property operations.
-        """
-        # Convert operations to request format
+    def _build_request_operations(self) -> list:
         request_operations = []
         for operation in self.operations:
             if operation.operation_type == OperationType.APPEND:
@@ -104,24 +94,36 @@ class TransformationAgent(_BaseAgent):
                     "Only APPEND and UPDATE operations are supported."
                 )
             request_operations.append(request_operation)
+        return request_operations
 
-        request = {
-            "collection": self.collection,
-            "operations": request_operations,
-            "headers": self._connection.additional_headers,
-        }
-
+    def _post_transformation(self, request: dict) -> TransformationResponse:
         with httpx.Client(timeout=self._timeout) as client:
             response = client.post(
                 self.t_host + "/properties",
                 json=request,
                 headers=self._headers,
             )
-
             if response.is_error:
                 raise Exception(response.text)
-
             return TransformationResponse(**response.json())
+
+    def update_all(self) -> TransformationResponse:
+        """Triggers all configured transformation operations on the collection.
+
+        Returns:
+            TransformationResponse: response with workflow ID for tracking transformation progress.
+
+        Raises:
+            httpx.HTTPError: If there is an error communicating with the transformation service.
+            ValueError: If the operations are not properly configured or if there are duplicate
+                property operations.
+        """
+        request = {
+            "collection": self.collection,
+            "operations": self._build_request_operations(),
+            "headers": self._connection.additional_headers,
+        }
+        return self._post_transformation(request)
 
     def get_status(self, workflow_id: str) -> dict:
         """Check the status of a transformation workflow.
@@ -145,3 +147,25 @@ class TransformationAgent(_BaseAgent):
                 raise Exception(response.text)
 
             return response.json()
+
+    def update_by_uuids(self, uuids: List[UUID]) -> TransformationResponse:
+        """Triggers all configured transformation operations on the specified UUIDs in the collection.
+
+        Args:
+            uuids: List of UUIDs to process.
+
+        Returns:
+            TransformationResponse: response with workflow ID for tracking transformation progress.
+
+        Raises:
+            httpx.HTTPError: If there is an error communicating with the transformation service.
+            ValueError: If the operations are not properly configured or if there are duplicate
+                property operations.
+        """
+        request = {
+            "collection": self.collection,
+            "operations": self._build_request_operations(),
+            "headers": self._connection.additional_headers,
+            "uuids": [str(u) for u in uuids],
+        }
+        return self._post_transformation(request)


### PR DESCRIPTION
This PR refactors the `TransformationAgent` class in `weaviate_agents/transformation/transformation_agent.py` to improve code modularity and adds a new method for targeted transformations. The most important changes include splitting the `update_all` method into smaller helper methods, introducing a new `update_by_uuids` method, and importing the `UUID` type for type annotations.

### Refactoring for modularity:

* Extracted `_build_request_operations` as a helper method to encapsulate the logic for constructing the list of transformation operations. 
* Added `_post_transformation` as a helper method to handle the HTTP POST request logic, making the code more reusable. 

### New functionality:

* Introduced `update_by_uuids` method to allow triggering transformations on specific UUIDs in the collection, enhancing the flexibility of the API. 