### PR TITLE
Add AsyncQueryAgent client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest>=8.3.4",
     "ruff>=0.9.6",
     "tomli>=2.2.1",
+    "pytest-asyncio>=0.26.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weaviate-agents"
-version = "0.7.1"
+version = "0.8.0"
 description = "The official sub-package for the Weaviate Agents project."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -238,11 +238,6 @@ def test_run_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_async_run_success(monkeypatch):
-    """Test that AsyncQueryAgent.run returns a valid QueryAgentResponse when the HTTP call is successful.
-
-    Returns:
-        None.
-    """
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_async_post_success)
     dummy_client = DummyClient()
     agent = AsyncQueryAgent(
@@ -286,11 +281,6 @@ def test_run_failure(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_async_run_failure(monkeypatch):
-    """Test that AsyncQueryAgent.run raises an exception when the HTTP response indicates an error.
-
-    Returns:
-        None.
-    """
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_async_post_failure)
     dummy_client = DummyClient()
     agent = AsyncQueryAgent(
@@ -355,7 +345,8 @@ def test_run_with_target_vector(monkeypatch):
             "test query",
             collections=[
                 QueryAgentCollectionConfig(
-                    name="test_collection", target_vector=["first_vector", "second_vector"]
+                    name="test_collection",
+                    target_vector=["first_vector", "second_vector"],
                 )
             ],
         )
@@ -401,7 +392,8 @@ async def test_async_run_with_target_vector(monkeypatch):
             "test query",
             collections=[
                 QueryAgentCollectionConfig(
-                    name="test_collection", target_vector=["first_vector", "second_vector"]
+                    name="test_collection",
+                    target_vector=["first_vector", "second_vector"],
                 )
             ],
         )

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -236,7 +236,6 @@ def test_run_success(monkeypatch):
     assert result.final_answer == "final answer"
 
 
-@pytest.mark.asyncio
 async def test_async_run_success(monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_async_post_success)
     dummy_client = DummyClient()
@@ -279,7 +278,6 @@ def test_run_failure(monkeypatch):
     )
 
 
-@pytest.mark.asyncio
 async def test_async_run_failure(monkeypatch):
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_async_post_failure)
     dummy_client = DummyClient()
@@ -357,7 +355,6 @@ def test_run_with_target_vector(monkeypatch):
     ]
 
 
-@pytest.mark.asyncio
 async def test_async_run_with_target_vector(monkeypatch):
     captured = {}
 

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -3,7 +3,7 @@ import pytest
 from pydantic import ValidationError
 
 from weaviate_agents.classes.query import QueryAgentCollectionConfig, QueryAgentResponse
-from weaviate_agents.query import QueryAgent
+from weaviate_agents.query import AsyncQueryAgent, QueryAgent
 
 
 class DummyClient:
@@ -188,6 +188,10 @@ def fake_post_success(*args, **kwargs) -> FakeResponse:
     return FakeResponse(200, json_data)
 
 
+async def fake_async_post_success(*args, **kwargs) -> FakeResponse:
+    return fake_post_success(*args, **kwargs)
+
+
 def fake_post_failure(*args, **kwargs) -> FakeResponse:
     """Simulate a failed HTTP POST response.
 
@@ -202,6 +206,10 @@ def fake_post_failure(*args, **kwargs) -> FakeResponse:
         }
     }
     return FakeResponse(400, json_data)
+
+
+async def fake_async_post_failure(*args, **kwargs):
+    return fake_post_failure(*args, **kwargs)
 
 
 def test_run_success(monkeypatch):
@@ -228,6 +236,31 @@ def test_run_success(monkeypatch):
     assert result.final_answer == "final answer"
 
 
+@pytest.mark.asyncio
+async def test_async_run_success(monkeypatch):
+    """Test that AsyncQueryAgent.run returns a valid QueryAgentResponse when the HTTP call is successful.
+
+    Returns:
+        None.
+    """
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_async_post_success)
+    dummy_client = DummyClient()
+    agent = AsyncQueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    with pytest.warns(UserWarning):
+        # Expect a warning when parsing the unkown "something_new" filter/aggregation
+        result = await agent.run("test query")
+    assert isinstance(result, QueryAgentResponse)
+    assert result.original_query == "test query"
+    assert result.collection_names == ["test_collection"]
+    assert result.total_time == 0.1
+    assert result.final_answer == "final answer"
+
+
 def test_run_failure(monkeypatch):
     """Test that QueryAgent.run raises an exception when the HTTP response indicates an error.
 
@@ -244,6 +277,30 @@ def test_run_failure(monkeypatch):
 
     with pytest.raises(Exception) as exc_info:
         agent.run("failure query")
+
+    assert (
+        str(exc_info.value)
+        == "{'error': {'message': 'Test error message', 'code': 'test_error_code', 'details': {'info': 'test detail'}}}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_run_failure(monkeypatch):
+    """Test that AsyncQueryAgent.run raises an exception when the HTTP response indicates an error.
+
+    Returns:
+        None.
+    """
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_async_post_failure)
+    dummy_client = DummyClient()
+    agent = AsyncQueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    with pytest.raises(Exception) as exc_info:
+        await agent.run("failure query")
 
     assert (
         str(exc_info.value)
@@ -291,6 +348,48 @@ def test_run_with_target_vector(monkeypatch):
 
     # Test with multiple target vectors
     result = agent.run(
+        "test query",
+        collections=[
+            QueryAgentCollectionConfig(
+                name="test_collection", target_vector=["first_vector", "second_vector"]
+            )
+        ],
+    )
+    assert isinstance(result, QueryAgentResponse)
+    assert captured["json"]["collections"][0]["target_vector"] == [
+        "first_vector",
+        "second_vector",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_run_with_target_vector(monkeypatch):
+    captured = {}
+
+    async def fake_async_post_with_capture(*args, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return await fake_async_post_success()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_async_post_with_capture)
+    dummy_client = DummyClient()
+    agent = AsyncQueryAgent(dummy_client, agents_host="http://dummy-agent")
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    # Test with single target vector
+    result = await agent.run(
+        "test query",
+        collections=[
+            QueryAgentCollectionConfig(
+                name="test_collection", target_vector="my_vector"
+            )
+        ],
+    )
+    assert isinstance(result, QueryAgentResponse)
+    assert captured["json"]["collections"][0]["target_vector"] == "my_vector"
+
+    # Test with multiple target vectors
+    result = await agent.run(
         "test query",
         collections=[
             QueryAgentCollectionConfig(

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -335,26 +335,30 @@ def test_run_with_target_vector(monkeypatch):
     agent._headers = dummy_client.additional_headers
 
     # Test with single target vector
-    result = agent.run(
-        "test query",
-        collections=[
-            QueryAgentCollectionConfig(
-                name="test_collection", target_vector="my_vector"
-            )
-        ],
-    )
+    with pytest.warns(UserWarning):
+        # Expect a warning when parsing the unkown "something_new" filter/aggregation
+        result = agent.run(
+            "test query",
+            collections=[
+                QueryAgentCollectionConfig(
+                    name="test_collection", target_vector="my_vector"
+                )
+            ],
+        )
     assert isinstance(result, QueryAgentResponse)
     assert captured["json"]["collections"][0]["target_vector"] == "my_vector"
 
     # Test with multiple target vectors
-    result = agent.run(
-        "test query",
-        collections=[
-            QueryAgentCollectionConfig(
-                name="test_collection", target_vector=["first_vector", "second_vector"]
-            )
-        ],
-    )
+    with pytest.warns(UserWarning):
+        # Expect a warning when parsing the unkown "something_new" filter/aggregation
+        result = agent.run(
+            "test query",
+            collections=[
+                QueryAgentCollectionConfig(
+                    name="test_collection", target_vector=["first_vector", "second_vector"]
+                )
+            ],
+        )
     assert isinstance(result, QueryAgentResponse)
     assert captured["json"]["collections"][0]["target_vector"] == [
         "first_vector",
@@ -377,26 +381,30 @@ async def test_async_run_with_target_vector(monkeypatch):
     agent._headers = dummy_client.additional_headers
 
     # Test with single target vector
-    result = await agent.run(
-        "test query",
-        collections=[
-            QueryAgentCollectionConfig(
-                name="test_collection", target_vector="my_vector"
-            )
-        ],
-    )
+    with pytest.warns(UserWarning):
+        # Expect a warning when parsing the unkown "something_new" filter/aggregation
+        result = await agent.run(
+            "test query",
+            collections=[
+                QueryAgentCollectionConfig(
+                    name="test_collection", target_vector="my_vector"
+                )
+            ],
+        )
     assert isinstance(result, QueryAgentResponse)
     assert captured["json"]["collections"][0]["target_vector"] == "my_vector"
 
     # Test with multiple target vectors
-    result = await agent.run(
-        "test query",
-        collections=[
-            QueryAgentCollectionConfig(
-                name="test_collection", target_vector=["first_vector", "second_vector"]
-            )
-        ],
-    )
+    with pytest.warns(UserWarning):
+        # Expect a warning when parsing the unkown "something_new" filter/aggregation
+        result = await agent.run(
+            "test query",
+            collections=[
+                QueryAgentCollectionConfig(
+                    name="test_collection", target_vector=["first_vector", "second_vector"]
+                )
+            ],
+        )
     assert isinstance(result, QueryAgentResponse)
     assert captured["json"]["collections"][0]["target_vector"] == [
         "first_vector",

--- a/uv.lock
+++ b/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "weaviate-agents"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 
 [[package]]
@@ -753,6 +754,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694 },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -948,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "weaviate-agents"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },
@@ -960,6 +974,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "tomli" },
@@ -976,6 +991,7 @@ dev = [
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.9.6" },
     { name = "tomli", specifier = ">=2.2.1" },

--- a/weaviate_agents/base.py
+++ b/weaviate_agents/base.py
@@ -1,9 +1,8 @@
-from typing import Union, TypeVar, Generic
+from typing import Generic, TypeVar, Union
 
-from weaviate.client import WeaviateClient, WeaviateAsyncClient
+from weaviate.client import WeaviateAsyncClient, WeaviateClient
 
-
-ClientType = TypeVar('ClientType', bound=Union[WeaviateClient, WeaviateAsyncClient])
+ClientType = TypeVar("ClientType", bound=Union[WeaviateClient, WeaviateAsyncClient])
 
 
 class _BaseAgent(Generic[ClientType]):

--- a/weaviate_agents/base.py
+++ b/weaviate_agents/base.py
@@ -1,16 +1,19 @@
-from typing import Union
+from typing import Union, TypeVar, Generic
 
-from weaviate.client import WeaviateClient
+from weaviate.client import WeaviateClient, WeaviateAsyncClient
 
 
-class _BaseAgent:
+ClientType = TypeVar('ClientType', bound=Union[WeaviateClient, WeaviateAsyncClient])
+
+
+class _BaseAgent(Generic[ClientType]):
     """
     Base class for all agents.
     """
 
     def __init__(
         self,
-        client: WeaviateClient,
+        client: ClientType,
         agents_host: Union[str, None] = None,
     ):
         """
@@ -21,7 +24,7 @@ class _BaseAgent:
             agents_host: Optional host URL for the agents service. If not provided,
                 will use the default agents host.
         """
-        self._client = client
+        self._client: ClientType = client
         self._connection = client._connection
         self._agents_host = agents_host or "https://api.agents.weaviate.io"
 

--- a/weaviate_agents/personalization/personalization_agent.py
+++ b/weaviate_agents/personalization/personalization_agent.py
@@ -18,7 +18,7 @@ from weaviate_agents.personalization.classes import (
 from weaviate_agents.personalization.query import PersonalizedQuery
 
 
-class PersonalizationAgent(_BaseAgent):
+class PersonalizationAgent(_BaseAgent[WeaviateClient]):
     """An agent for personalizing search results and queries based on persona interactions.
 
     Warning:

--- a/weaviate_agents/query/__init__.py
+++ b/weaviate_agents/query/__init__.py
@@ -1,3 +1,3 @@
-from .query_agent import QueryAgent
+from .query_agent import AsyncQueryAgent, QueryAgent
 
-__all__ = ["QueryAgent"]
+__all__ = ["AsyncQueryAgent", "QueryAgent"]

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Any, Coroutine, Optional, Union, Generic
+from typing import Any, Coroutine, Generic, Optional, Union
 
 import httpx
-from weaviate.client import WeaviateClient, WeaviateAsyncClient
+from weaviate.client import WeaviateAsyncClient, WeaviateClient
 
-from weaviate_agents.base import _BaseAgent, ClientType
+from weaviate_agents.base import ClientType, _BaseAgent
 from weaviate_agents.query.classes import QueryAgentCollectionConfig, QueryAgentResponse
 
 

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -7,7 +7,7 @@ from weaviate_agents.base import _BaseAgent
 from weaviate_agents.query.classes import QueryAgentCollectionConfig, QueryAgentResponse
 
 
-class QueryAgent(_BaseAgent):
+class QueryAgent(_BaseAgent[WeaviateClient]):
     """An agent for executing agentic queries against Weaviate.
 
     Warning:

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -1,13 +1,14 @@
-from typing import Optional, Union
+from abc import ABC, abstractmethod
+from typing import Any, Coroutine, Optional, Union, Generic
 
 import httpx
-from weaviate.client import WeaviateClient
+from weaviate.client import WeaviateClient, WeaviateAsyncClient
 
-from weaviate_agents.base import _BaseAgent
+from weaviate_agents.base import _BaseAgent, ClientType
 from weaviate_agents.query.classes import QueryAgentCollectionConfig, QueryAgentResponse
 
 
-class QueryAgent(_BaseAgent[WeaviateClient]):
+class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
     """An agent for executing agentic queries against Weaviate.
 
     Warning:
@@ -19,13 +20,13 @@ class QueryAgent(_BaseAgent[WeaviateClient]):
 
     def __init__(
         self,
-        client: WeaviateClient,
+        client: ClientType,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         agents_host: Union[str, None] = None,
         system_prompt: Union[str, None] = None,
         timeout: Union[int, None] = None,
     ):
-        """Initialize the QueryAgent.
+        """Initialize the Query Agent.
 
         Warning:
             Weaviate Agents - Query Agent is an early stage alpha product. The API is subject to
@@ -49,6 +50,58 @@ class QueryAgent(_BaseAgent[WeaviateClient]):
 
         self.q_host = f"{self._agents_host}/agent/query"
 
+    def _prepare_request_body(
+        self,
+        query: str,
+        collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
+        context: Optional[QueryAgentResponse] = None,
+    ) -> dict:
+        """Prepare the request body for the query.
+
+        Args:
+            query: The natural language query string for the agent.
+            collections: The collections to query. Will override any collections if passed in the constructor.
+            context: Optional previous response from the agent.
+        """
+        collections = collections or self._collections
+        if not collections:
+            raise ValueError("No collections provided to the query agent.")
+
+        return {
+            "query": query,
+            "collections": [
+                collection
+                if isinstance(collection, str)
+                else collection.model_dump(mode="json")
+                for collection in collections
+            ],
+            "headers": self._connection.additional_headers,
+            "limit": 20,
+            "previous_response": context.model_dump(mode="json") if context else None,
+            "system_prompt": self._system_prompt,
+        }
+
+    @abstractmethod
+    def run(
+        self,
+        query: str,
+        collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
+        context: Optional[QueryAgentResponse] = None,
+    ) -> Union[QueryAgentResponse, Coroutine[Any, Any, QueryAgentResponse]]:
+        """Run the query agent. Must be implemented by subclasses."""
+        pass
+
+
+class QueryAgent(_BaseQueryAgent[WeaviateClient]):
+    """An agent for executing agentic queries against Weaviate.
+
+    Warning:
+        Weaviate Agents - Query Agent is an early stage alpha product. The API is subject to
+        breaking changes. Please ensure you are using the latest version of the client.
+
+        For more information, see the [Weaviate Agents - Query Agent Docs](https://weaviate.io/developers/agents/query)
+    """
+
     def run(
         self,
         query: str,
@@ -63,24 +116,7 @@ class QueryAgent(_BaseAgent[WeaviateClient]):
             collections: The collections to query. Will override any collections if passed in the constructor.
             context: Optional previous response from the agent.
         """
-
-        collections = collections or self._collections
-        if not collections:
-            raise ValueError("No collections provided to the query agent.")
-
-        request_body = {
-            "query": query,
-            "collections": [
-                collection
-                if isinstance(collection, str)
-                else collection.model_dump(mode="json")
-                for collection in collections
-            ],
-            "headers": self._connection.additional_headers,
-            "limit": 20,
-            "previous_response": context.model_dump(mode="json") if context else None,
-            "system_prompt": self._system_prompt,
-        }
+        request_body = self._prepare_request_body(query, collections, context)
 
         response = httpx.post(
             self.q_host,
@@ -93,3 +129,43 @@ class QueryAgent(_BaseAgent[WeaviateClient]):
             raise Exception(response.text)
 
         return QueryAgentResponse(**response.json())
+
+
+class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
+    """An agent for executing agentic queries against Weaviate.
+
+    Warning:
+        Weaviate Agents - Query Agent is an early stage alpha product. The API is subject to
+        breaking changes. Please ensure you are using the latest version of the client.
+
+        For more information, see the [Weaviate Agents - Query Agent Docs](https://weaviate.io/developers/agents/query)
+    """
+
+    async def run(
+        self,
+        query: str,
+        collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
+        context: Optional[QueryAgentResponse] = None,
+    ) -> QueryAgentResponse:
+        """
+        Run the query agent.
+
+        Args:
+            query: The natural language query string for the agent.
+            collections: The collections to query. Will override any collections if passed in the constructor.
+            context: Optional previous response from the agent.
+        """
+        request_body = self._prepare_request_body(query, collections, context)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self.q_host,
+                headers=self._headers,
+                json=request_body,
+                timeout=self._timeout,
+            )
+
+            if response.is_error:
+                raise Exception(response.text)
+
+            return QueryAgentResponse(**response.json())

--- a/weaviate_agents/transformation/transformation_agent.py
+++ b/weaviate_agents/transformation/transformation_agent.py
@@ -14,7 +14,7 @@ from weaviate_agents.transformation.classes import (
 )
 
 
-class TransformationAgent(_BaseAgent):
+class TransformationAgent(_BaseAgent[WeaviateClient]):
     """An agent for running large scale transformations on data in Weaviate.
 
     Warning:


### PR DESCRIPTION
Adds an async version of the Query Agent client:
- Makes the `_BaseAgent` class generic over client type (bound to either the sync or async clients)
- Adds a `_BaseQueryAgent` class (again, generic over the client type) which contains the logic for constructing requests (not so important for QA, but will be a useful pattern to avoid repetition once the other agents get async clients too)
- Adds the new `AsyncQueryAgent` client