### PR TITLE
Add option to skip final state when streaming QA 

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -971,7 +971,7 @@ wheels = [
 
 [[package]]
 name = "weaviate-agents"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx-sse" },

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -1,6 +1,16 @@
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
-from typing import Any, AsyncGenerator, Coroutine, Generator, Generic, Literal, Optional, Union, overload
+from typing import (
+    Any,
+    AsyncGenerator,
+    Coroutine,
+    Generator,
+    Generic,
+    Literal,
+    Optional,
+    Union,
+    overload,
+)
 
 import httpx
 from httpx_sse import ServerSentEvent, aconnect_sse, connect_sse
@@ -103,9 +113,14 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         include_progress: Literal[True] = True,
         include_final_state: Literal[True] = True,
     ) -> Union[
-        Generator[Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None, None],
-        AsyncGenerator[Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None],
-    ]: pass
+        Generator[
+            Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None, None
+        ],
+        AsyncGenerator[
+            Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None
+        ],
+    ]:
+        pass
 
     @overload
     def stream(
@@ -118,7 +133,8 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
     ) -> Union[
         Generator[Union[ProgressMessage, StreamedTokens], None, None],
         AsyncGenerator[Union[ProgressMessage, StreamedTokens], None],
-    ]: pass
+    ]:
+        pass
 
     @overload
     def stream(
@@ -131,7 +147,8 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
     ) -> Union[
         Generator[Union[StreamedTokens, QueryAgentResponse], None, None],
         AsyncGenerator[Union[StreamedTokens, QueryAgentResponse], None],
-    ]: pass
+    ]:
+        pass
 
     @overload
     def stream(
@@ -144,7 +161,8 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
     ) -> Union[
         Generator[StreamedTokens, None, None],
         AsyncGenerator[StreamedTokens, None],
-    ]: pass
+    ]:
+        pass
 
     @abstractmethod
     def stream(
@@ -158,7 +176,9 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         Generator[
             Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None, None
         ],
-        AsyncGenerator[Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None],
+        AsyncGenerator[
+            Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None
+        ],
     ]:
         """Stream from the query agent. Must be implemented by subclasses."""
         pass
@@ -209,7 +229,9 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         context: Optional[QueryAgentResponse] = None,
         include_progress: Literal[True] = True,
         include_final_state: Literal[True] = True,
-    ) -> Generator[Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None, None]: ...
+    ) -> Generator[
+        Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None, None
+    ]: ...
 
     @overload
     def stream(
@@ -323,7 +345,9 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         context: Optional[QueryAgentResponse] = None,
         include_progress: Literal[True] = True,
         include_final_state: Literal[True] = True,
-    ) -> AsyncGenerator[Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None]: ...
+    ) -> AsyncGenerator[
+        Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None
+    ]: ...
 
     @overload
     def stream(

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -101,6 +101,7 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         context: Optional[QueryAgentResponse] = None,
         include_progress: bool = True,
+        include_final_state: bool = True,
     ) -> Union[
         Generator[
             Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None, None
@@ -156,6 +157,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         context: Optional[QueryAgentResponse] = None,
         include_progress: bool = True,
+        include_final_state: bool = True,
     ) -> Generator[
         Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None, None
     ]:
@@ -164,6 +166,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             collections,
             context,
             include_progress=include_progress,
+            include_final_state=include_final_state,
         )
         with httpx.Client() as client:
             with connect_sse(
@@ -222,6 +225,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         context: Optional[QueryAgentResponse] = None,
         include_progress: bool = True,
+        include_final_state: bool = True,
     ) -> AsyncGenerator[
         Union[ProgressMessage, StreamedTokens, QueryAgentResponse], None
     ]:
@@ -230,6 +234,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             collections,
             context,
             include_progress=include_progress,
+            include_final_state=include_final_state,
         )
         async with httpx.AsyncClient() as client:
             async with aconnect_sse(


### PR DESCRIPTION
This adds a new option to the QA streaming to skip the final state being yielded. Also adds type overloading to the stream methods so that the output types are correctly narrowed depending on `include_progress` and `include_final_state`:

<img width="491" alt="qa_overload_sync" src="https://github.com/user-attachments/assets/8e491f41-8a77-4e4d-9390-169e9c713e93" />

<img width="600" alt="qa_overload_async" src="https://github.com/user-attachments/assets/f064a3e5-786a-495b-9707-ec92eaedf821" />