### PR TITLE
Revert "release (#60)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weaviate-agents"
-version = "0.12.1"
+version = "0.12.0"
 description = "The official sub-package for the Weaviate Agents project."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
This reverts commit f17b746e7abbaaecf39c49411939901d46db83fe.

Apparently `0.12.0` was not released yet, so reverting to that.