### PR TITLE
Add `filtering` argument to Search Mode

### DIFF
--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -797,6 +797,54 @@ def test_search_only_mode_without_diversity_weight(monkeypatch):
     assert captured["json"]["diversity_weight"] is None
 
 
+def test_search_only_mode_with_search_strategy(monkeypatch):
+    captured = {}
+
+    def fake_post_with_capture(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return fake_post_search_only_success()
+
+    monkeypatch.setattr(httpx, "post", fake_post_with_capture)
+    dummy_client = DummyClient()
+    agent = QueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    # Test with search_strategy set
+    results = agent.search("test query", limit=2, search_strategy="recall")
+    assert isinstance(results, SearchModeResponse)
+    assert captured["json"]["search_strategy"] == "recall"
+
+    # Reset captured json, then paginate — search_strategy should persist
+    captured = {}
+    results_2 = results.next(limit=2, offset=1)
+    assert isinstance(results_2, SearchModeResponse)
+    assert captured["json"]["search_strategy"] == "recall"
+
+
+def test_search_only_mode_without_search_strategy(monkeypatch):
+    captured = {}
+
+    def fake_post_with_capture(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return fake_post_search_only_success()
+
+    monkeypatch.setattr(httpx, "post", fake_post_with_capture)
+    dummy_client = DummyClient()
+    agent = QueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    # Test without search_strategy — should default to None
+    results = agent.search("test query", limit=2)
+    assert isinstance(results, SearchModeResponse)
+    assert captured["json"]["search_strategy"] is None
+
+
 def test_search_only_mode_failure(monkeypatch):
     monkeypatch.setattr(httpx, "post", fake_post_failure)
     dummy_client = DummyClient()
@@ -891,6 +939,33 @@ async def test_async_search_only_mode_with_diversity_weight(monkeypatch):
     results_2 = await results.next(limit=2, offset=1)
     assert isinstance(results_2, AsyncSearchModeResponse)
     assert captured["json"]["diversity_weight"] == 0.7
+
+
+async def test_async_search_only_mode_with_search_strategy(monkeypatch):
+    captured = {}
+
+    async def fake_post_with_capture(self, url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return await fake_async_post_search_only_success()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post_with_capture)
+    dummy_client = DummyClient()
+    agent = AsyncQueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    # Test with search_strategy set
+    results = await agent.search("test query", limit=2, search_strategy="precision")
+    assert isinstance(results, AsyncSearchModeResponse)
+    assert captured["json"]["search_strategy"] == "precision"
+
+    # Reset captured json, then paginate — search_strategy should persist
+    captured = {}
+    results_2 = await results.next(limit=2, offset=1)
+    assert isinstance(results_2, AsyncSearchModeResponse)
+    assert captured["json"]["search_strategy"] == "precision"
 
 
 async def test_async_search_only_mode_failure(monkeypatch):

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -824,7 +824,7 @@ def test_search_only_mode_with_search_strategy(monkeypatch):
     assert captured["json"]["search_strategy"] == "recall"
 
 
-def test_search_only_mode_without_search_strategy(monkeypatch):
+def test_search_only_mode_default_search_strategy(monkeypatch):
     captured = {}
 
     def fake_post_with_capture(url, headers=None, json=None, timeout=None):
@@ -839,10 +839,10 @@ def test_search_only_mode_without_search_strategy(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test without search_strategy — should default to None
+    # Test without search_strategy — should default to "recall"
     results = agent.search("test query", limit=2)
     assert isinstance(results, SearchModeResponse)
-    assert captured["json"]["search_strategy"] is None
+    assert captured["json"]["search_strategy"] == "recall"
 
 
 def test_search_only_mode_failure(monkeypatch):

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -839,10 +839,10 @@ def test_search_only_mode_default_filtering(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test without filtering — should default to "recall"
+    # Test without filtering — should default to None
     results = agent.search("test query", limit=2)
     assert isinstance(results, SearchModeResponse)
-    assert captured["json"]["filtering"] == "recall"
+    assert captured["json"]["filtering"] is None
 
 
 def test_search_only_mode_failure(monkeypatch):

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -797,7 +797,7 @@ def test_search_only_mode_without_diversity_weight(monkeypatch):
     assert captured["json"]["diversity_weight"] is None
 
 
-def test_search_only_mode_with_search_strategy(monkeypatch):
+def test_search_only_mode_with_retrieval_strategy(monkeypatch):
     captured = {}
 
     def fake_post_with_capture(url, headers=None, json=None, timeout=None):
@@ -812,19 +812,19 @@ def test_search_only_mode_with_search_strategy(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test with search_strategy set
-    results = agent.search("test query", limit=2, search_strategy="recall")
+    # Test with retrieval_strategy set
+    results = agent.search("test query", limit=2, retrieval_strategy="recall")
     assert isinstance(results, SearchModeResponse)
-    assert captured["json"]["search_strategy"] == "recall"
+    assert captured["json"]["retrieval_strategy"] == "recall"
 
-    # Reset captured json, then paginate — search_strategy should persist
+    # Reset captured json, then paginate — retrieval_strategy should persist
     captured = {}
     results_2 = results.next(limit=2, offset=1)
     assert isinstance(results_2, SearchModeResponse)
-    assert captured["json"]["search_strategy"] == "recall"
+    assert captured["json"]["retrieval_strategy"] == "recall"
 
 
-def test_search_only_mode_default_search_strategy(monkeypatch):
+def test_search_only_mode_default_retrieval_strategy(monkeypatch):
     captured = {}
 
     def fake_post_with_capture(url, headers=None, json=None, timeout=None):
@@ -839,10 +839,10 @@ def test_search_only_mode_default_search_strategy(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test without search_strategy — should default to "recall"
+    # Test without retrieval_strategy — should default to "recall"
     results = agent.search("test query", limit=2)
     assert isinstance(results, SearchModeResponse)
-    assert captured["json"]["search_strategy"] == "recall"
+    assert captured["json"]["retrieval_strategy"] == "recall"
 
 
 def test_search_only_mode_failure(monkeypatch):
@@ -941,7 +941,7 @@ async def test_async_search_only_mode_with_diversity_weight(monkeypatch):
     assert captured["json"]["diversity_weight"] == 0.7
 
 
-async def test_async_search_only_mode_with_search_strategy(monkeypatch):
+async def test_async_search_only_mode_with_retrieval_strategy(monkeypatch):
     captured = {}
 
     async def fake_post_with_capture(self, url, headers=None, json=None, timeout=None):
@@ -956,16 +956,16 @@ async def test_async_search_only_mode_with_search_strategy(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test with search_strategy set
-    results = await agent.search("test query", limit=2, search_strategy="precision")
+    # Test with retrieval_strategy set
+    results = await agent.search("test query", limit=2, retrieval_strategy="precision")
     assert isinstance(results, AsyncSearchModeResponse)
-    assert captured["json"]["search_strategy"] == "precision"
+    assert captured["json"]["retrieval_strategy"] == "precision"
 
-    # Reset captured json, then paginate — search_strategy should persist
+    # Reset captured json, then paginate — retrieval_strategy should persist
     captured = {}
     results_2 = await results.next(limit=2, offset=1)
     assert isinstance(results_2, AsyncSearchModeResponse)
-    assert captured["json"]["search_strategy"] == "precision"
+    assert captured["json"]["retrieval_strategy"] == "precision"
 
 
 async def test_async_search_only_mode_failure(monkeypatch):

--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -797,7 +797,7 @@ def test_search_only_mode_without_diversity_weight(monkeypatch):
     assert captured["json"]["diversity_weight"] is None
 
 
-def test_search_only_mode_with_retrieval_strategy(monkeypatch):
+def test_search_only_mode_with_filtering(monkeypatch):
     captured = {}
 
     def fake_post_with_capture(url, headers=None, json=None, timeout=None):
@@ -812,19 +812,19 @@ def test_search_only_mode_with_retrieval_strategy(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test with retrieval_strategy set
-    results = agent.search("test query", limit=2, retrieval_strategy="recall")
+    # Test with filtering set
+    results = agent.search("test query", limit=2, filtering="recall")
     assert isinstance(results, SearchModeResponse)
-    assert captured["json"]["retrieval_strategy"] == "recall"
+    assert captured["json"]["filtering"] == "recall"
 
-    # Reset captured json, then paginate — retrieval_strategy should persist
+    # Reset captured json, then paginate — filtering should persist
     captured = {}
     results_2 = results.next(limit=2, offset=1)
     assert isinstance(results_2, SearchModeResponse)
-    assert captured["json"]["retrieval_strategy"] == "recall"
+    assert captured["json"]["filtering"] == "recall"
 
 
-def test_search_only_mode_default_retrieval_strategy(monkeypatch):
+def test_search_only_mode_default_filtering(monkeypatch):
     captured = {}
 
     def fake_post_with_capture(url, headers=None, json=None, timeout=None):
@@ -839,10 +839,10 @@ def test_search_only_mode_default_retrieval_strategy(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test without retrieval_strategy — should default to "recall"
+    # Test without filtering — should default to "recall"
     results = agent.search("test query", limit=2)
     assert isinstance(results, SearchModeResponse)
-    assert captured["json"]["retrieval_strategy"] == "recall"
+    assert captured["json"]["filtering"] == "recall"
 
 
 def test_search_only_mode_failure(monkeypatch):
@@ -941,7 +941,7 @@ async def test_async_search_only_mode_with_diversity_weight(monkeypatch):
     assert captured["json"]["diversity_weight"] == 0.7
 
 
-async def test_async_search_only_mode_with_retrieval_strategy(monkeypatch):
+async def test_async_search_only_mode_with_filtering(monkeypatch):
     captured = {}
 
     async def fake_post_with_capture(self, url, headers=None, json=None, timeout=None):
@@ -956,16 +956,16 @@ async def test_async_search_only_mode_with_retrieval_strategy(monkeypatch):
     agent._connection = dummy_client
     agent._headers = dummy_client.additional_headers
 
-    # Test with retrieval_strategy set
-    results = await agent.search("test query", limit=2, retrieval_strategy="precision")
+    # Test with filtering set
+    results = await agent.search("test query", limit=2, filtering="precision")
     assert isinstance(results, AsyncSearchModeResponse)
-    assert captured["json"]["retrieval_strategy"] == "precision"
+    assert captured["json"]["filtering"] == "precision"
 
-    # Reset captured json, then paginate — retrieval_strategy should persist
+    # Reset captured json, then paginate — filtering should persist
     captured = {}
     results_2 = await results.next(limit=2, offset=1)
     assert isinstance(results_2, AsyncSearchModeResponse)
-    assert captured["json"]["retrieval_strategy"] == "precision"
+    assert captured["json"]["filtering"] == "precision"
 
 
 async def test_async_search_only_mode_failure(monkeypatch):

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -17,7 +17,7 @@ class SearchModeRequestBase(BaseModel):
     collections: list[Union[str, QueryAgentCollectionConfig]]
     limit: int
     offset: int
-    filtering: Literal["recall", "precision"]
+    filtering: Optional[Literal["recall", "precision"]] = None
     diversity_weight: Optional[float] = None
 
 

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -18,6 +18,7 @@ class SearchModeRequestBase(BaseModel):
     limit: int
     offset: int
     diversity_weight: Optional[float] = None
+    search_strategy: Optional[Literal["recall", "precision"]] = None
 
 
 class SearchModeExecutionRequest(SearchModeRequestBase):

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -17,8 +17,8 @@ class SearchModeRequestBase(BaseModel):
     collections: list[Union[str, QueryAgentCollectionConfig]]
     limit: int
     offset: int
-    diversity_weight: Optional[float] = None
     search_strategy: Literal["recall", "precision"] = "recall"
+    diversity_weight: Optional[float] = None
 
 
 class SearchModeExecutionRequest(SearchModeRequestBase):

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -17,7 +17,7 @@ class SearchModeRequestBase(BaseModel):
     collections: list[Union[str, QueryAgentCollectionConfig]]
     limit: int
     offset: int
-    filtering: Literal["recall", "precision"] = "recall"
+    filtering: Literal["recall", "precision"]
     diversity_weight: Optional[float] = None
 
 

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -17,7 +17,7 @@ class SearchModeRequestBase(BaseModel):
     collections: list[Union[str, QueryAgentCollectionConfig]]
     limit: int
     offset: int
-    search_strategy: Literal["recall", "precision"] = "recall"
+    retrieval_strategy: Literal["recall", "precision"] = "recall"
     diversity_weight: Optional[float] = None
 
 

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -17,7 +17,7 @@ class SearchModeRequestBase(BaseModel):
     collections: list[Union[str, QueryAgentCollectionConfig]]
     limit: int
     offset: int
-    retrieval_strategy: Literal["recall", "precision"] = "recall"
+    filtering: Literal["recall", "precision"] = "recall"
     diversity_weight: Optional[float] = None
 
 

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -18,7 +18,7 @@ class SearchModeRequestBase(BaseModel):
     limit: int
     offset: int
     diversity_weight: Optional[float] = None
-    search_strategy: Optional[Literal["recall", "precision"]] = None
+    search_strategy: Literal["recall", "precision"] = "recall"
 
 
 class SearchModeExecutionRequest(SearchModeRequestBase):

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -1032,6 +1032,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             filtering: The filtering strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
+                Defaults to "recall".
             diversity_weight: Optional float between 0.0 and 1.0 to diversify
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
@@ -1677,6 +1678,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             filtering: The filtering strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
+                Defaults to "recall".
             diversity_weight: Optional float between 0.0 and 1.0 to diversify
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -498,8 +498,8 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        diversity_weight: Optional[float] = None,
         search_strategy: Literal["recall", "precision"] = "recall",
+        diversity_weight: Optional[float] = None,
     ) -> Union[SearchModeResponse, Coroutine[Any, Any, AsyncSearchModeResponse]]:
         pass
 
@@ -1014,8 +1014,8 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        diversity_weight: Optional[float] = None,
         search_strategy: Literal["recall", "precision"] = "recall",
+        diversity_weight: Optional[float] = None,
     ) -> SearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -1029,14 +1029,14 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             limit: The maximum number of results to return for the first page.
             collections: The collections to query. Either a list of strings, or a list of :class:`~weaviate_agents.query.classes.QueryAgentCollectionConfig` objects.
                 Overrides any collections provided in the constructor when set.
+            search_strategy: The search strategy to use for this search.
+                Use "recall" to optimize for finding all relevant results,
+                or "precision" to optimize for the accuracy of returned results.
+                Defaults to "recall".
             diversity_weight: Optional float between 0.0 and 1.0 to diversify
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
                 Defaults to None (no diversity).
-            search_strategy: The search strategy to use for this search.
-                Use ``"recall"`` to optimize for finding all relevant results,
-                or ``"precision"`` to optimize for the accuracy of returned results.
-                Defaults to ``"recall"``.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.SearchModeResponse` for the first page of results. Use
@@ -1071,8 +1071,8 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             query=query,
             collections=collections,
             system_prompt=self._system_prompt,
-            diversity_weight=diversity_weight,
             search_strategy=search_strategy,
+            diversity_weight=diversity_weight,
         )
         return searcher.run(limit=limit)
 
@@ -1659,8 +1659,8 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        diversity_weight: Optional[float] = None,
         search_strategy: Literal["recall", "precision"] = "recall",
+        diversity_weight: Optional[float] = None,
     ) -> AsyncSearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -1675,14 +1675,14 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             limit: The maximum number of results to return for the first page.
             collections: The collections to query. Overrides any collections
                 provided in the constructor when set.
+            search_strategy: The search strategy to use for this search.
+                Use "recall" to optimize for finding all relevant results,
+                or "precision" to optimize for the accuracy of returned results.
+                Defaults to "recall".
             diversity_weight: Optional float between 0.0 and 1.0 to diversify
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
                 Defaults to None (no diversity).
-            search_strategy: The search strategy to use for this search.
-                Use ``"recall"`` to optimize for finding all relevant results,
-                or ``"precision"`` to optimize for the accuracy of returned results.
-                Defaults to ``"recall"``.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.AsyncSearchModeResponse` for the first page of results. Use
@@ -1717,8 +1717,8 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             query=query,
             collections=collections,
             system_prompt=self._system_prompt,
-            diversity_weight=diversity_weight,
             search_strategy=search_strategy,
+            diversity_weight=diversity_weight,
         )
         return await searcher.run(limit=limit)
 

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -499,6 +499,7 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         diversity_weight: Optional[float] = None,
+        search_strategy: Optional[Literal["recall", "precision"]] = None,
     ) -> Union[SearchModeResponse, Coroutine[Any, Any, AsyncSearchModeResponse]]:
         pass
 
@@ -1014,6 +1015,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         diversity_weight: Optional[float] = None,
+        search_strategy: Optional[Literal["recall", "precision"]] = None,
     ) -> SearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -1031,6 +1033,10 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
                 Defaults to None (no diversity).
+            search_strategy: The search strategy to use for this search.
+                Use ``"recall"`` to optimize for finding all relevant results,
+                or ``"precision"`` to optimize for the accuracy of returned results.
+                Defaults to None.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.SearchModeResponse` for the first page of results. Use
@@ -1066,6 +1072,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             collections=collections,
             system_prompt=self._system_prompt,
             diversity_weight=diversity_weight,
+            search_strategy=search_strategy,
         )
         return searcher.run(limit=limit)
 
@@ -1653,6 +1660,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         diversity_weight: Optional[float] = None,
+        search_strategy: Optional[Literal["recall", "precision"]] = None,
     ) -> AsyncSearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -1671,6 +1679,10 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
                 Defaults to None (no diversity).
+            search_strategy: The search strategy to use for this search.
+                Use ``"recall"`` to optimize for finding all relevant results,
+                or ``"precision"`` to optimize for the accuracy of returned results.
+                Defaults to None.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.AsyncSearchModeResponse` for the first page of results. Use
@@ -1706,6 +1718,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             collections=collections,
             system_prompt=self._system_prompt,
             diversity_weight=diversity_weight,
+            search_strategy=search_strategy,
         )
         return await searcher.run(limit=limit)
 

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -498,7 +498,7 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        search_strategy: Literal["recall", "precision"] = "recall",
+        retrieval_strategy: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ) -> Union[SearchModeResponse, Coroutine[Any, Any, AsyncSearchModeResponse]]:
         pass
@@ -1014,7 +1014,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        search_strategy: Literal["recall", "precision"] = "recall",
+        retrieval_strategy: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ) -> SearchModeResponse:
         """Run the Query Agent search-only mode.
@@ -1029,7 +1029,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             limit: The maximum number of results to return for the first page.
             collections: The collections to query. Either a list of strings, or a list of :class:`~weaviate_agents.query.classes.QueryAgentCollectionConfig` objects.
                 Overrides any collections provided in the constructor when set.
-            search_strategy: The search strategy to use for this search.
+            retrieval_strategy: The retrieval strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
                 Defaults to "recall".
@@ -1071,7 +1071,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             query=query,
             collections=collections,
             system_prompt=self._system_prompt,
-            search_strategy=search_strategy,
+            retrieval_strategy=retrieval_strategy,
             diversity_weight=diversity_weight,
         )
         return searcher.run(limit=limit)
@@ -1659,7 +1659,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        search_strategy: Literal["recall", "precision"] = "recall",
+        retrieval_strategy: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ) -> AsyncSearchModeResponse:
         """Run the Query Agent search-only mode.
@@ -1675,7 +1675,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             limit: The maximum number of results to return for the first page.
             collections: The collections to query. Overrides any collections
                 provided in the constructor when set.
-            search_strategy: The search strategy to use for this search.
+            retrieval_strategy: The retrieval strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
                 Defaults to "recall".
@@ -1717,7 +1717,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             query=query,
             collections=collections,
             system_prompt=self._system_prompt,
-            search_strategy=search_strategy,
+            retrieval_strategy=retrieval_strategy,
             diversity_weight=diversity_weight,
         )
         return await searcher.run(limit=limit)

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -498,7 +498,7 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        retrieval_strategy: Literal["recall", "precision"] = "recall",
+        filtering: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ) -> Union[SearchModeResponse, Coroutine[Any, Any, AsyncSearchModeResponse]]:
         pass
@@ -1014,7 +1014,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        retrieval_strategy: Literal["recall", "precision"] = "recall",
+        filtering: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ) -> SearchModeResponse:
         """Run the Query Agent search-only mode.
@@ -1029,7 +1029,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             limit: The maximum number of results to return for the first page.
             collections: The collections to query. Either a list of strings, or a list of :class:`~weaviate_agents.query.classes.QueryAgentCollectionConfig` objects.
                 Overrides any collections provided in the constructor when set.
-            retrieval_strategy: The retrieval strategy to use for this search.
+            filtering: The filtering strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
                 Defaults to "recall".
@@ -1071,7 +1071,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             query=query,
             collections=collections,
             system_prompt=self._system_prompt,
-            retrieval_strategy=retrieval_strategy,
+            filtering=filtering,
             diversity_weight=diversity_weight,
         )
         return searcher.run(limit=limit)
@@ -1659,7 +1659,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        retrieval_strategy: Literal["recall", "precision"] = "recall",
+        filtering: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ) -> AsyncSearchModeResponse:
         """Run the Query Agent search-only mode.
@@ -1675,7 +1675,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             limit: The maximum number of results to return for the first page.
             collections: The collections to query. Overrides any collections
                 provided in the constructor when set.
-            retrieval_strategy: The retrieval strategy to use for this search.
+            filtering: The filtering strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
                 Defaults to "recall".
@@ -1717,7 +1717,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             query=query,
             collections=collections,
             system_prompt=self._system_prompt,
-            retrieval_strategy=retrieval_strategy,
+            filtering=filtering,
             diversity_weight=diversity_weight,
         )
         return await searcher.run(limit=limit)

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -499,7 +499,7 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         diversity_weight: Optional[float] = None,
-        search_strategy: Optional[Literal["recall", "precision"]] = None,
+        search_strategy: Literal["recall", "precision"] = "recall",
     ) -> Union[SearchModeResponse, Coroutine[Any, Any, AsyncSearchModeResponse]]:
         pass
 
@@ -1015,7 +1015,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         diversity_weight: Optional[float] = None,
-        search_strategy: Optional[Literal["recall", "precision"]] = None,
+        search_strategy: Literal["recall", "precision"] = "recall",
     ) -> SearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -1036,7 +1036,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             search_strategy: The search strategy to use for this search.
                 Use ``"recall"`` to optimize for finding all relevant results,
                 or ``"precision"`` to optimize for the accuracy of returned results.
-                Defaults to None.
+                Defaults to ``"recall"``.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.SearchModeResponse` for the first page of results. Use
@@ -1660,7 +1660,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         diversity_weight: Optional[float] = None,
-        search_strategy: Optional[Literal["recall", "precision"]] = None,
+        search_strategy: Literal["recall", "precision"] = "recall",
     ) -> AsyncSearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -1682,7 +1682,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             search_strategy: The search strategy to use for this search.
                 Use ``"recall"`` to optimize for finding all relevant results,
                 or ``"precision"`` to optimize for the accuracy of returned results.
-                Defaults to None.
+                Defaults to ``"recall"``.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.AsyncSearchModeResponse` for the first page of results. Use

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -498,7 +498,7 @@ class _BaseQueryAgent(Generic[ClientType], _BaseAgent[ClientType], ABC):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        filtering: Literal["recall", "precision"] = "recall",
+        filtering: Optional[Literal["recall", "precision"]] = None,
         diversity_weight: Optional[float] = None,
     ) -> Union[SearchModeResponse, Coroutine[Any, Any, AsyncSearchModeResponse]]:
         pass
@@ -1014,7 +1014,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        filtering: Literal["recall", "precision"] = "recall",
+        filtering: Optional[Literal["recall", "precision"]] = None,
         diversity_weight: Optional[float] = None,
     ) -> SearchModeResponse:
         """Run the Query Agent search-only mode.
@@ -1032,7 +1032,6 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             filtering: The filtering strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
-                Defaults to "recall".
             diversity_weight: Optional float between 0.0 and 1.0 to diversify
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
@@ -1659,7 +1658,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         query: Union[str, list[ChatMessage]],
         limit: int = 20,
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
-        filtering: Literal["recall", "precision"] = "recall",
+        filtering: Optional[Literal["recall", "precision"]] = None,
         diversity_weight: Optional[float] = None,
     ) -> AsyncSearchModeResponse:
         """Run the Query Agent search-only mode.
@@ -1678,7 +1677,6 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             filtering: The filtering strategy to use for this search.
                 Use "recall" to optimize for finding all relevant results,
                 or "precision" to optimize for the accuracy of returned results.
-                Defaults to "recall".
             diversity_weight: Optional float between 0.0 and 1.0 to diversify
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -35,7 +35,7 @@ class _BaseQueryAgentSearcher:
         query: Union[str, list[ChatMessage]],
         collections: list[Union[str, QueryAgentCollectionConfig]],
         system_prompt: Optional[str],
-        search_strategy: Literal["recall", "precision"] = "recall",
+        retrieval_strategy: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ):
         self.headers = headers
@@ -45,7 +45,7 @@ class _BaseQueryAgentSearcher:
         self.query = query
         self.collections = collections
         self.system_prompt = system_prompt
-        self.search_strategy = search_strategy
+        self.retrieval_strategy = retrieval_strategy
         self.diversity_weight = diversity_weight
         self._cached_searches: Optional[list[QueryResultWithCollectionNormalized]] = (
             None
@@ -65,7 +65,7 @@ class _BaseQueryAgentSearcher:
                 limit=limit,
                 offset=offset,
                 system_prompt=self.system_prompt,
-                search_strategy=self.search_strategy,
+                retrieval_strategy=self.retrieval_strategy,
                 diversity_weight=self.diversity_weight,
             ).model_dump(mode="json")
         else:
@@ -76,7 +76,7 @@ class _BaseQueryAgentSearcher:
                 limit=limit,
                 offset=offset,
                 searches=self._cached_searches,
-                search_strategy=self.search_strategy,
+                retrieval_strategy=self.retrieval_strategy,
                 diversity_weight=self.diversity_weight,
             ).model_dump(mode="json")
 

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -36,7 +36,7 @@ class _BaseQueryAgentSearcher:
         collections: list[Union[str, QueryAgentCollectionConfig]],
         system_prompt: Optional[str],
         diversity_weight: Optional[float] = None,
-        search_strategy: Optional[Literal["recall", "precision"]] = None,
+        search_strategy: Literal["recall", "precision"] = "recall",
     ):
         self.headers = headers
         self.connection_headers = connection_headers

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -35,7 +35,7 @@ class _BaseQueryAgentSearcher:
         query: Union[str, list[ChatMessage]],
         collections: list[Union[str, QueryAgentCollectionConfig]],
         system_prompt: Optional[str],
-        filtering: Literal["recall", "precision"] = "recall",
+        filtering: Optional[Literal["recall", "precision"]] = None,
         diversity_weight: Optional[float] = None,
     ):
         self.headers = headers

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -97,7 +97,7 @@ class QueryAgentSearcher(_BaseQueryAgentSearcher):
             raise Exception(response.text)
 
         parsed_response = SearchModeResponse(**response.json())
-        if parsed_response.searches:
+        if parsed_response.searches is not None:
             self._cached_searches = parsed_response.searches
         parsed_response._searcher = self
         return parsed_response
@@ -142,7 +142,7 @@ class AsyncQueryAgentSearcher(_BaseQueryAgentSearcher):
             raise Exception(response.text)
 
         parsed_response = AsyncSearchModeResponse(**response.json())
-        if parsed_response.searches:
+        if parsed_response.searches is not None:
             self._cached_searches = parsed_response.searches
         parsed_response._searcher = self
         return parsed_response

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import httpx
 
@@ -36,6 +36,7 @@ class _BaseQueryAgentSearcher:
         collections: list[Union[str, QueryAgentCollectionConfig]],
         system_prompt: Optional[str],
         diversity_weight: Optional[float] = None,
+        search_strategy: Optional[Literal["recall", "precision"]] = None,
     ):
         self.headers = headers
         self.connection_headers = connection_headers
@@ -45,6 +46,7 @@ class _BaseQueryAgentSearcher:
         self.collections = collections
         self.system_prompt = system_prompt
         self.diversity_weight = diversity_weight
+        self.search_strategy = search_strategy
         self._cached_searches: Optional[list[QueryResultWithCollectionNormalized]] = (
             None
         )
@@ -64,6 +66,7 @@ class _BaseQueryAgentSearcher:
                 offset=offset,
                 system_prompt=self.system_prompt,
                 diversity_weight=self.diversity_weight,
+                search_strategy=self.search_strategy,
             ).model_dump(mode="json")
         else:
             return SearchModeExecutionRequest(
@@ -74,6 +77,7 @@ class _BaseQueryAgentSearcher:
                 offset=offset,
                 searches=self._cached_searches,
                 diversity_weight=self.diversity_weight,
+                search_strategy=self.search_strategy,
             ).model_dump(mode="json")
 
 

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -35,8 +35,8 @@ class _BaseQueryAgentSearcher:
         query: Union[str, list[ChatMessage]],
         collections: list[Union[str, QueryAgentCollectionConfig]],
         system_prompt: Optional[str],
-        diversity_weight: Optional[float] = None,
         search_strategy: Literal["recall", "precision"] = "recall",
+        diversity_weight: Optional[float] = None,
     ):
         self.headers = headers
         self.connection_headers = connection_headers
@@ -45,8 +45,8 @@ class _BaseQueryAgentSearcher:
         self.query = query
         self.collections = collections
         self.system_prompt = system_prompt
-        self.diversity_weight = diversity_weight
         self.search_strategy = search_strategy
+        self.diversity_weight = diversity_weight
         self._cached_searches: Optional[list[QueryResultWithCollectionNormalized]] = (
             None
         )
@@ -65,8 +65,8 @@ class _BaseQueryAgentSearcher:
                 limit=limit,
                 offset=offset,
                 system_prompt=self.system_prompt,
-                diversity_weight=self.diversity_weight,
                 search_strategy=self.search_strategy,
+                diversity_weight=self.diversity_weight,
             ).model_dump(mode="json")
         else:
             return SearchModeExecutionRequest(
@@ -76,8 +76,8 @@ class _BaseQueryAgentSearcher:
                 limit=limit,
                 offset=offset,
                 searches=self._cached_searches,
-                diversity_weight=self.diversity_weight,
                 search_strategy=self.search_strategy,
+                diversity_weight=self.diversity_weight,
             ).model_dump(mode="json")
 
 

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -35,7 +35,7 @@ class _BaseQueryAgentSearcher:
         query: Union[str, list[ChatMessage]],
         collections: list[Union[str, QueryAgentCollectionConfig]],
         system_prompt: Optional[str],
-        retrieval_strategy: Literal["recall", "precision"] = "recall",
+        filtering: Literal["recall", "precision"] = "recall",
         diversity_weight: Optional[float] = None,
     ):
         self.headers = headers
@@ -45,7 +45,7 @@ class _BaseQueryAgentSearcher:
         self.query = query
         self.collections = collections
         self.system_prompt = system_prompt
-        self.retrieval_strategy = retrieval_strategy
+        self.filtering = filtering
         self.diversity_weight = diversity_weight
         self._cached_searches: Optional[list[QueryResultWithCollectionNormalized]] = (
             None
@@ -65,7 +65,7 @@ class _BaseQueryAgentSearcher:
                 limit=limit,
                 offset=offset,
                 system_prompt=self.system_prompt,
-                retrieval_strategy=self.retrieval_strategy,
+                filtering=self.filtering,
                 diversity_weight=self.diversity_weight,
             ).model_dump(mode="json")
         else:
@@ -76,7 +76,7 @@ class _BaseQueryAgentSearcher:
                 limit=limit,
                 offset=offset,
                 searches=self._cached_searches,
-                retrieval_strategy=self.retrieval_strategy,
+                filtering=self.filtering,
                 diversity_weight=self.diversity_weight,
             ).model_dump(mode="json")
 


### PR DESCRIPTION
### Description

Adds a `filtering` parameter to the Query Agent's Search Mode. This allows users to control the trade-off between recall and precision.

The parameter accepts two values: `"recall"` to optimize for finding all relevant results, or `"precision"` to optimize for the accuracy of returned results.

Usage example:

```python
agent = QueryAgent(
  client=client, 
  collections=["FinancialContracts"]
)
                                                                                
# Default behavior (recall) 
results = agent.search("Find all NDAs signed by Jane Doe in 2024.")           
                                                                                
# Optimize for precision
results = agent.search(
  "Find all NDAs signed by Jane Doe in 2024.",
  filtering="precision"
)
``` 

### Pagination Fix

Empty search lists are cached from precision mode's ability to output no searches, ensuring pagination requests are consistent.