### PR TITLE
Add `effort` to Search Mode

### DIFF
--- a/test/query_agent/test_query_model.py
+++ b/test/query_agent/test_query_model.py
@@ -845,6 +845,54 @@ def test_search_only_mode_default_filtering(monkeypatch):
     assert captured["json"]["filtering"] is None
 
 
+def test_search_only_mode_with_effort(monkeypatch):
+    captured = {}
+
+    def fake_post_with_capture(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return fake_post_search_only_success()
+
+    monkeypatch.setattr(httpx, "post", fake_post_with_capture)
+    dummy_client = DummyClient()
+    agent = QueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    # Test with effort set
+    results = agent.search("test query", limit=2, effort="high")
+    assert isinstance(results, SearchModeResponse)
+    assert captured["json"]["effort"] == "high"
+
+    # Reset captured json, then paginate — effort should persist
+    captured = {}
+    results_2 = results.next(limit=2, offset=1)
+    assert isinstance(results_2, SearchModeResponse)
+    assert captured["json"]["effort"] == "high"
+
+
+def test_search_only_mode_default_effort(monkeypatch):
+    captured = {}
+
+    def fake_post_with_capture(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return fake_post_search_only_success()
+
+    monkeypatch.setattr(httpx, "post", fake_post_with_capture)
+    dummy_client = DummyClient()
+    agent = QueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    # Test without effort — should default to None
+    results = agent.search("test query", limit=2)
+    assert isinstance(results, SearchModeResponse)
+    assert captured["json"]["effort"] is None
+
+
 def test_search_only_mode_failure(monkeypatch):
     monkeypatch.setattr(httpx, "post", fake_post_failure)
     dummy_client = DummyClient()
@@ -966,6 +1014,33 @@ async def test_async_search_only_mode_with_filtering(monkeypatch):
     results_2 = await results.next(limit=2, offset=1)
     assert isinstance(results_2, AsyncSearchModeResponse)
     assert captured["json"]["filtering"] == "precision"
+
+
+async def test_async_search_only_mode_with_effort(monkeypatch):
+    captured = {}
+
+    async def fake_post_with_capture(self, url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return await fake_async_post_search_only_success()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post_with_capture)
+    dummy_client = DummyClient()
+    agent = AsyncQueryAgent(
+        dummy_client, ["test_collection"], agents_host="http://dummy-agent"
+    )
+    agent._connection = dummy_client
+    agent._headers = dummy_client.additional_headers
+
+    # Test with effort set
+    results = await agent.search("test query", limit=2, effort="low")
+    assert isinstance(results, AsyncSearchModeResponse)
+    assert captured["json"]["effort"] == "low"
+
+    # Reset captured json, then paginate — effort should persist
+    captured = {}
+    results_2 = await results.next(limit=2, offset=1)
+    assert isinstance(results_2, AsyncSearchModeResponse)
+    assert captured["json"]["effort"] == "low"
 
 
 async def test_async_search_only_mode_failure(monkeypatch):

--- a/weaviate_agents/query/classes/request.py
+++ b/weaviate_agents/query/classes/request.py
@@ -19,6 +19,7 @@ class SearchModeRequestBase(BaseModel):
     offset: int
     filtering: Optional[Literal["recall", "precision"]] = None
     diversity_weight: Optional[float] = None
+    effort: Optional[Literal["low", "medium", "high"]] = None
 
 
 class SearchModeExecutionRequest(SearchModeRequestBase):

--- a/weaviate_agents/query/query_agent.py
+++ b/weaviate_agents/query/query_agent.py
@@ -1405,6 +1405,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         filtering: Optional[Literal["recall", "precision"]] = None,
         diversity_weight: Optional[float] = None,
+        effort: Optional[Literal["low", "medium", "high"]] = None,
     ) -> SearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -1426,6 +1427,9 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
                 Defaults to None (no diversity).
+            effort: The amount of effort the agent should put into the search.
+                One of "low", "medium", or "high". Higher effort may improve
+                result quality at the expense of increased latency and cost.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.SearchModeResponse` for the first page of results. Use
@@ -1462,6 +1466,7 @@ class QueryAgent(_BaseQueryAgent[WeaviateClient]):
             system_prompt=self._system_prompt,
             filtering=filtering,
             diversity_weight=diversity_weight,
+            effort=effort,
         )
         return searcher.run(limit=limit)
 
@@ -2257,6 +2262,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
         collections: Union[list[Union[str, QueryAgentCollectionConfig]], None] = None,
         filtering: Optional[Literal["recall", "precision"]] = None,
         diversity_weight: Optional[float] = None,
+        effort: Optional[Literal["low", "medium", "high"]] = None,
     ) -> AsyncSearchModeResponse:
         """Run the Query Agent search-only mode.
 
@@ -2279,6 +2285,9 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
                 results with MMR reranking.
                 Higher values push for more topical variety at the cost of relevance.
                 Defaults to None (no diversity).
+            effort: The amount of effort the agent should put into the search.
+                One of "low", "medium", or "high". Higher effort may improve
+                result quality at the expense of increased latency and cost.
 
         Returns:
             An instance of :class:`~weaviate_agents.query.classes.response.AsyncSearchModeResponse` for the first page of results. Use
@@ -2315,6 +2324,7 @@ class AsyncQueryAgent(_BaseQueryAgent[WeaviateAsyncClient]):
             system_prompt=self._system_prompt,
             filtering=filtering,
             diversity_weight=diversity_weight,
+            effort=effort,
         )
         return await searcher.run(limit=limit)
 

--- a/weaviate_agents/query/search.py
+++ b/weaviate_agents/query/search.py
@@ -37,6 +37,7 @@ class _BaseQueryAgentSearcher:
         system_prompt: Optional[str],
         filtering: Optional[Literal["recall", "precision"]] = None,
         diversity_weight: Optional[float] = None,
+        effort: Optional[Literal["low", "medium", "high"]] = None,
     ):
         self.headers = headers
         self.connection_headers = connection_headers
@@ -47,6 +48,7 @@ class _BaseQueryAgentSearcher:
         self.system_prompt = system_prompt
         self.filtering = filtering
         self.diversity_weight = diversity_weight
+        self.effort = effort
         self._cached_searches: Optional[list[QueryResultWithCollectionNormalized]] = (
             None
         )
@@ -67,6 +69,7 @@ class _BaseQueryAgentSearcher:
                 system_prompt=self.system_prompt,
                 filtering=self.filtering,
                 diversity_weight=self.diversity_weight,
+                effort=self.effort,
             ).model_dump(mode="json")
         else:
             return SearchModeExecutionRequest(
@@ -78,6 +81,7 @@ class _BaseQueryAgentSearcher:
                 searches=self._cached_searches,
                 filtering=self.filtering,
                 diversity_weight=self.diversity_weight,
+                effort=self.effort,
             ).model_dump(mode="json")
 
 


### PR DESCRIPTION
## What's Changed

Adds an optional `effort: Literal["low", "medium", "high"]` parameter to Search Mode, available on both `QueryAgent.search()` and `AsyncQueryAgent.search()`. Higher effort may improve result quality at the expense of increased latency and cost. Defaults to `None` (no behavior change for existing callers).

```python
qa.search(
  "Comparisons of Setwise and Listwise rerankers.", 
  effort="high"
)
```

The parameter is threaded through the searcher and stored on it, so it persists across pagination, `response.next()` sends the same `effort` value on every page. This follows the same pattern as the existing `filtering` and `diversity_weight` parameters.

## Changes

- `weaviate_agents/query/classes/request.py`: add `effort` field to `SearchModeRequestBase` (included in both generation and execution requests)
- `weaviate_agents/query/search.py`: accept and store `effort` on `_BaseQueryAgentSearcher`, include it in request bodies
- `weaviate_agents/query/query_agent.py`: add `effort` parameter to sync and async `search()` with docstrings
- `test/query_agent/test_query_model.py`: tests for effort being sent, persisting across pagination, and defaulting to `None`
